### PR TITLE
added support for searching for department code + number with whitespace

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -735,6 +735,7 @@ class Database:
 
         res = list(self._db.mappings.find({'$or': [
             {'displayname': {'$regex': query}},
+            {'displayname_whitespace': {'$regex': query}},
             {'title': {'$regex': query}}
         ]}))
 

--- a/src/monitor_utils.py
+++ b/src/monitor_utils.py
@@ -61,6 +61,7 @@ def get_course_in_mobileapp(term, course_, curr_time):
             new = {
                 'courseid': courseid,
                 'displayname': subject['code'] + course['catalog_number'],
+                'displayname_whitespace': subject['code'] + ' ' + course['catalog_number'],
                 'title': course['title'],
                 'time': curr_time
             }
@@ -71,6 +72,8 @@ def get_course_in_mobileapp(term, course_, curr_time):
             for x in course['crosslistings']:
                 new['displayname'] += '/' + \
                     x['subject'] + x['catalog_number']
+                new['displayname_whitespace'] += '/' + \
+                    x['subject'] + ' ' + x['catalog_number']
 
             new_mapping = new.copy()
             del new['time']

--- a/src/schema.py
+++ b/src/schema.py
@@ -9,7 +9,8 @@ CLASS_SCHEMA = ('classid', 'section', 'type_name',
                 'start_time', 'end_time', 'days')
 
 # mappings collection
-MAPPINGS_SCHEMA = ('displayname', 'title', 'courseid', 'time')
+MAPPINGS_SCHEMA = ('displayname', 'displayname_whitespace',
+                   'title', 'courseid', 'time')
 
 # enrollments collection
 ENROLLMENTS_SCHEMA = ('classid', 'enrollment', 'capacity')

--- a/src/update_all_courses_utils.py
+++ b/src/update_all_courses_utils.py
@@ -61,12 +61,15 @@ def process_dept_code(args):
                 new = {
                     'courseid': courseid,
                     'displayname': subject['code'] + course['catalog_number'],
+                    'displayname_whitespace': subject['code'] + ' ' + course['catalog_number'],
                     'title': course['title'],
                     'time': time.time()}
 
                 for x in course['crosslistings']:
                     new['displayname'] += '/' + \
                         x['subject'] + x['catalog_number']
+                    new['displayname_whitespace'] += '/' + \
+                        x['subject'] + ' ' + x['catalog_number']
 
                 print('inserting', new['displayname'], 'into mappings')
                 db.add_to_mappings(new)


### PR DESCRIPTION
Previously, searching for `COS 126` would yield no results (searching for `COS126` with no whitespace would work). This problem has been fixed via the addition of one field to the database collection `mappings`. The database has also been rebuilt to accommodate this change.