### PR TITLE
add backend logic to disable/enable course subscriptions

### DIFF
--- a/app.py
+++ b/app.py
@@ -273,6 +273,7 @@ def get_course():
         last_query_unquoted=unquote_plus(new_query),
         notifs_online=_db.get_cron_notification_status(),
         next_notifs=_db.get_current_or_next_notifs_interval(),
+        is_course_disabled=_db.is_course_disabled(courseid)
     )
 
     return make_response(html)
@@ -346,6 +347,7 @@ def get_course_info(courseid):
         section_names=section_names,
         notifs_online=_db.get_cron_notification_status(),
         next_notifs=_db.get_current_or_next_notifs_interval(),
+        is_course_disabled=_db.is_course_disabled(courseid)
     )
     return make_response(html)
 
@@ -469,6 +471,25 @@ def admin():
 # ACCESSIBLE BY ADMIN ONLY, NOT VIA URL
 # ----------------------------------------------------------------------
 
+@app.route("/disable_course/<courseid>", methods=["POST"])
+def disable_course(courseid):
+    netid = _cas.authenticate()
+    try:
+        if not is_admin(netid, _db):
+            return redirect(url_for("landing"))
+    except:
+        return redirect(url_for("landing"))
+    return jsonify({"isSuccess": _db.add_disabled_course(courseid.strip())})
+
+@app.route("/enable_course/<courseid>", methods=["POST"])
+def enable_course(courseid):
+    netid = _cas.authenticate()
+    try:
+        if not is_admin(netid, _db):
+            return redirect(url_for("landing"))
+    except:
+        return redirect(url_for("landing"))
+    return jsonify({"isSuccess": _db.remove_disabled_course(courseid.strip())})
 
 @app.route("/add_to_blacklist/<user>", methods=["POST"])
 def add_to_blacklist(user):

--- a/src/database.py
+++ b/src/database.py
@@ -181,6 +181,30 @@ class Database:
     # ADMIN PANEL METHODS
     # ----------------------------------------------------------------------
 
+    def add_disabled_course(self, courseid):
+        course_data = self.get_course(courseid)
+        if not course_data:
+            raise Exception(f"{courseid} is not a valid course ID.")
+            return False
+        try:
+            self._db.admin.update_one({}, { "$addToSet": { "disabled_courses": courseid }})
+            return True
+        except:
+            raise Exception(f"Could not add {courseid} to list of disabled courses.")
+            return False
+    
+    def remove_disabled_course(self, courseid):
+        course_data = self.get_course(courseid)
+        if not course_data:
+            raise Exception(f"{courseid} is not a valid course ID.")
+            return False
+        try:
+            self._db.admin.update_one({}, { "$pull": { "disabled_courses": courseid }})
+            return True
+        except:
+            raise Exception(f"Could not remove {courseid} from list of disabled courses.")
+            return False
+
     # prints log and adds log to admin collection to track admin activity
 
     def _add_admin_log(self, log):
@@ -923,6 +947,14 @@ class Database:
         )
 
         return res
+    
+    def is_course_disabled(self, courseid):
+        try:
+            disabled_courses = self._db.admin.find_one({}, 
+                {"disabled_courses": 1, "_id": 0})["disabled_courses"]
+            return courseid in disabled_courses
+        except:
+            return False
 
     # ----------------------------------------------------------------------
     # CLASS METHODS
@@ -949,9 +981,9 @@ class Database:
         except:
             raise RuntimeError(f"classid {classid} not found in enrollments")
 
-    # returns the corresponding course displayname for a given classid
+    # returns the corresponding course displayname and courseid for a given classid
 
-    def classid_to_course_deptnum(self, classid):
+    def classid_to_course_info(self, classid):
         try:
             courseid = self._db.enrollments.find_one({"classid": classid})["courseid"]
         except:
@@ -964,7 +996,8 @@ class Database:
         except:
             raise RuntimeError(f"courseid {courseid} not found in courses")
 
-        return displayname.split("/")[0]
+        return (displayname.split("/")[0], courseid)
+
 
     # returns information about a class including course depts, numbers, title
     # and section number, for display in email/text messages

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -25,9 +25,13 @@ class Monitor:
 
         for class_ in waited_classes:
             classid = class_["classid"]
-            deptnum = self._db.classid_to_course_deptnum(classid)
+            deptnum, courseid = self._db.classid_to_course_info(classid)
 
-            print("adding classid", classid, "from", deptnum)
+            # skip sections whose course is disabled
+            if self._db.is_course_disabled(courseid):
+                continue
+
+            print("adding classid", classid, "from", deptnum, "with courseid", courseid)
 
             if deptnum in data:
                 data[deptnum].append(classid)

--- a/views/course/course_header.html
+++ b/views/course/course_header.html
@@ -2,8 +2,7 @@
   <span class="badge bg-warning text-dark font-monospace px-1 py-1 fs-5"
     >{{ course_details.displayname.split('/')[0] }}
   </span>
-  <!-- TODO: replace the conditional logic with a flag for whether or not a course is disabled -->
-  {% if 0==1 %}
+  {% if is_course_disabled %}
   <span
     class="badge bg-danger text-light font-monospace fw-bold px-1 py-1 ms-2 fs-5"
     style="cursor: help; padding-bottom: 0.2rem !important"

--- a/views/course/course_table_row.html
+++ b/views/course/course_table_row.html
@@ -2,7 +2,6 @@
 {% if class.isFull %} {% if class.classid in curr_waitlists %}
 <td>
   <div class="form-check form-switch">
-    <!-- TODO: replace the conditional logic with a flag for whether or not a course is disabled -->
     <input
       class="form-check-input waitlist-switch"
       type="checkbox"
@@ -11,20 +10,19 @@
       data-bs-toggle="modal"
       data-bs-target="#confirm-remove-waitlist"
       checked
-      {% if 0==1 %}disabled{% endif %}
+      {% if is_course_disabled %} disabled {% endif %}
     />
   </div>
 </td>
 {% else %}
 <td>
   <div class="form-check form-switch">
-    <!-- TODO: replace the conditional logic with a flag for whether or not a course is disabled -->
     <input
       class="form-check-input waitlist-switch"
       type="checkbox"
       id="switch-{{class.classid}}"
       data-classid="{{class.classid}}"
-      {% if 0==1 %}disabled{% endif %}
+      {% if is_course_disabled %} disabled {% endif %}
     />
   </div>
 </td>


### PR DESCRIPTION
- store `disabled_courses` as set of course ids in admin table in DB
- set up `disable_course`, `enable_course` endpoints
- create `add_disabled_course`, `remove_disabled_course` methods in Database class
- when constructing list of waited classes for email notifications, do not add class to list if its corresponding course is disabled
- add `is_course_disabled `flag to disable/enable course switches and show/hide disabled label on course page

**Disable Course Subscriptions**

https://user-images.githubusercontent.com/63625700/130334728-51104cb3-39e1-4070-bb33-33439f582a8a.mov

**Enable Course Subscriptions**

https://user-images.githubusercontent.com/63625700/130334791-5492a378-2aa7-459a-b67f-635abf98bdd5.mov
