### PR TITLE
Use SendGrid instead of SMTP for emails

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Werkzeug==1.0.1
 requests==2.25.1
 Jinja2==2.11.3
 dnspython==1.16.0
-APScheduler==3.0.0
+APScheduler==3.7.0
 heroku3==4.2.3
 pandas==1.2.3
 sendgrid==6.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ dnspython==1.16.0
 APScheduler==3.0.0
 heroku3==4.2.3
 pandas==1.2.3
+sendgrid==6.0.5

--- a/src/config.py
+++ b/src/config.py
@@ -40,6 +40,9 @@ HEROKU_APP_NAME = environ["HEROKU_APP_NAME"]
 TS_EMAIL = environ["TS_EMAIL"]
 TS_PASSWORD = environ["TS_PASSWORD"]
 
+# TigerSnatch SendGrid API key
+SENDGRID_API_KEY = environ["SENDGRID_API_KEY"]
+
 # minimum time interval on which new course data is fetched (triggered)
 # on the front end web interface
 COURSE_UPDATE_INTERVAL_MINS = int(environ["COURSE_UPDATE_INTERVAL_MINS"])


### PR DESCRIPTION
## Context
Using SMTP with the TigerSnatch Exchange account has a limit of 300 emails per day. This limit is far too low for TigerSnatch, so we are switching to SendGrid, an email service with a nice API. This service is paid but allows us to send up to 100k emails per month.

* API key named "TigerSnatch Primary" in SendGrid is being used
    * This API key has been added as a Config Var in both the staging and prod TigerSnatchapps
* Created an entirely separate test database and linked to TigerSnatch stage site (https://tigersnatch-stage.herokuapp.com/admin)
* Manually filled ORF309 L01 and subscribed
* Ran `heroku run python src/send_notifs.py -a tigersnatch-stage` (i.e. a single run of the notifications algorithm) and an email was successfully sent to me with the correct information
    * ![image](https://user-images.githubusercontent.com/13815069/130387653-dcd73376-4ffd-47f5-a89c-c80370a49913.png)
* Note that APScheduler had to be updated in `requirements.txt` for some reason to fix a bug