### PR TITLE
Implement automatic un-subscription upon notification of open spots

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -522,7 +522,7 @@ class Database:
         res = []
 
         for classid in classids:
-            deptnum, name, section = self.classid_to_classinfo(classid)
+            deptnum, name, section, _ = self.classid_to_classinfo(classid)
             res.append(f"{name} ({deptnum}): {section}")
 
         if len(res) == 0:
@@ -576,7 +576,7 @@ class Database:
             data = [e for e in data[:n]]
             res = [f"Top {len(data)} most-subscribed sections:"]
             for n, classid in data:
-                deptnum, name, section = self.classid_to_classinfo(classid)
+                deptnum, name, section, _ = self.classid_to_classinfo(classid)
                 res.append(f"[{n}] {name} ({deptnum}): {section}")
             return res
 
@@ -638,7 +638,7 @@ class Database:
             data.sort(key=lambda x: x[0], reverse=True)
             res = []
             for n, classid in data:
-                deptnum, name, section = self.classid_to_classinfo(classid)
+                deptnum, name, section, _ = self.classid_to_classinfo(classid)
                 res.append(f"[{n}] {name} ({deptnum}): {section}")
             return res
 
@@ -1044,7 +1044,7 @@ class Database:
             raise Exception(f"courseid {courseid} cannot be found")
 
         dept_num = displayname.split("/")[0]
-        return dept_num, title, sectionname
+        return dept_num, title, sectionname, courseid
 
     # get dictionary for class with given classid in courses
 

--- a/src/notify.py
+++ b/src/notify.py
@@ -17,9 +17,12 @@ class Notify:
     def __init__(self, classid, i, n_new_slots, db, swap=False):
         self._classid = classid
         try:
-            self._deptnum, self._title, self._sectionname = db.classid_to_classinfo(
-                classid
-            )
+            (
+                self._deptnum,
+                self._title,
+                self._sectionname,
+                self._courseid,
+            ) = db.classid_to_classinfo(classid)
             self._coursename = f"{self._deptnum}: {self._title}"
             self._netid = db.get_class_waitlist(classid)["waitlist"][i]
         except:
@@ -53,7 +56,7 @@ class Notify:
             <p>Dear {self._netid},</p>
             <p>Your subscribed section <b>{self._sectionname}</b> in <b>{self._coursename}</b> has one or more spots open!</p>
             <p>Head over to <a href="https://phubprod.princeton.edu/psp/phubprod/?cmd=start">TigerHub</a> to Snatch your spot!</p>
-            <p>You'll continue to receive notifications for this section every 2 minutes if spots are still available. To unsubscribe from notifications for this section, please visit <a href="https://tigersnatch.herokuapp.com">TigerSnatch</a>.</p>
+            <p>You have been <b>automatically unsubscribed</b> from this section. If you didn't get the spot, you may re-subscribe here: <a href="https://snatch.tigerapps.org/course?query=&courseid={self._courseid}&skip">TigerSnatch | {self._deptnum}</a>.</p>
             <p>Best,<br>TigerSnatch Team <3</p>
         </body>
         </html>

--- a/src/notify.py
+++ b/src/notify.py
@@ -14,7 +14,7 @@ class Notify:
     # to format and send an email to the first student on the waitlist
     # for that classid
 
-    def __init__(self, classid, i, n_new_slots, db, swap=False):
+    def __init__(self, classid, i, n_new_slots, db):
         self._classid = classid
         try:
             (
@@ -36,12 +36,7 @@ class Notify:
         )
         db.update_user_waitlist_log(self._netid, user_log)
 
-        self._swap = swap
-        if swap:
-            self._netid_swap = ""
-            self._sectionname_swap = ""
-
-    # returns the primary (non-swap) netid of this Notify object
+    # returns the netid of this Notify object
 
     def get_netid(self):
         return self._netid
@@ -84,11 +79,6 @@ class Notify:
         ret += f"\tCourse:\t\t{self._coursename}\n"
         ret += f"\tSection:\t{self._sectionname}\n"
         ret += f"\tClassID:\t{self._classid}"
-
-        if self._swap:
-            ret += f"\n\tSwap with:\t{self._netid_swap}\n"
-            ret += f"\tSwap section:\t{self._sectionname_swap}"
-
         return ret
 
 

--- a/src/notify.py
+++ b/src/notify.py
@@ -36,6 +36,9 @@ class Notify:
         )
         db.update_user_waitlist_log(self._netid, user_log)
 
+        # unsubscribe user
+        db.remove_from_waitlist(self._netid, self._classid)
+
     # returns the netid of this Notify object
 
     def get_netid(self):


### PR DESCRIPTION
## Based on the results of https://forms.gle/kHvWrkGhiMFGf6k69, we have implemented the following changes:
* Automatic un-subscription of a user from a section when the user gets an email about open spots in that section
* Wording change in the email notification to inform users of the auto un-subscription
* Addition of a course-specific TigerSnatch link so that users can quickly resubscribe to the section in case they didn't get the spot opening

## Screenshot of the new email:
![image](https://user-images.githubusercontent.com/13815069/130527501-6e8785c0-d551-4500-9291-3f5fec9438bb.png)

The direct TigerSnatch course link in the last line is: https://snatch.tigerapps.org/course?query=&courseid=002053&skip