### PR TITLE
Change 2 minutes to 5 minutes for notifications frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
         <p class="fw-light text-center mt-4 fs-5 tutorial-text">
             It's that simple! The next time a spot opens up in a subscribed section, you'll
             be notified immediately via email. You will continue receiving notifications
-            every 2 minutes until this section is full again, or you unsubscribe from it. To
+            every 5 minutes until this section is full again, or you unsubscribe from it. To
             unsubscribe from a particular section, simply log back onto TigerSnatch and
             toggle the section's switch off in the Dashboard.
         </p>

--- a/src/notify.py
+++ b/src/notify.py
@@ -48,7 +48,7 @@ class Notify:
             <p>Dear {self._netid},</p>
             <p>Your subscribed section <b>{self._sectionname}</b> in <b>{self._coursename}</b> has one or more spots open!</p>
             <p>Head over to <a href="https://phubprod.princeton.edu/psp/phubprod/?cmd=start">TigerHub</a> to Snatch your spot!</p>
-            <p>You'll continue to receive notifications for this section every 2 minutes if spots are still available. To unsubscribe from notifications for this section, visit your <a href="https://snatch.tigerapps.org/dashboard">TigerSnatch Dashboard</a>.</p>
+            <p>You'll continue to receive notifications for this section <b>every 5 minutes</b> if spots are still available. To unsubscribe from notifications for this section, visit your <a href="https://snatch.tigerapps.org/dashboard">TigerSnatch Dashboard</a>.</p>
             <p>Best,<br>TigerSnatch Team <3</p>
         </body>
         </html>"""

--- a/src/notify.py
+++ b/src/notify.py
@@ -14,7 +14,7 @@ class Notify:
     # to format and send an email to the first student on the waitlist
     # for that classid
 
-    def __init__(self, classid, i, n_new_slots, db, swap=False):
+    def __init__(self, classid, i, n_new_slots, db):
         self._classid = classid
         try:
             self._deptnum, self._title, self._sectionname = db.classid_to_classinfo(
@@ -33,12 +33,7 @@ class Notify:
         )
         db.update_user_waitlist_log(self._netid, user_log)
 
-        self._swap = swap
-        if swap:
-            self._netid_swap = ""
-            self._sectionname_swap = ""
-
-    # returns the primary (non-swap) netid of this Notify object
+    # returns the primary netid of this Notify object
 
     def get_netid(self):
         return self._netid
@@ -81,11 +76,6 @@ class Notify:
         ret += f"\tCourse:\t\t{self._coursename}\n"
         ret += f"\tSection:\t{self._sectionname}\n"
         ret += f"\tClassID:\t{self._classid}"
-
-        if self._swap:
-            ret += f"\n\tSwap with:\t{self._netid_swap}\n"
-            ret += f"\tSwap section:\t{self._sectionname_swap}"
-
         return ret
 
 

--- a/src/notify.py
+++ b/src/notify.py
@@ -48,11 +48,10 @@ class Notify:
             <p>Dear {self._netid},</p>
             <p>Your subscribed section <b>{self._sectionname}</b> in <b>{self._coursename}</b> has one or more spots open!</p>
             <p>Head over to <a href="https://phubprod.princeton.edu/psp/phubprod/?cmd=start">TigerHub</a> to Snatch your spot!</p>
-            <p>You'll continue to receive notifications for this section every 2 minutes if spots are still available. To unsubscribe from notifications for this section, please visit <a href="https://tigersnatch.herokuapp.com">TigerSnatch</a>.</p>
+            <p>You'll continue to receive notifications for this section every 2 minutes if spots are still available. To unsubscribe from notifications for this section, visit your <a href="https://snatch.tigerapps.org/dashboard">TigerSnatch Dashboard</a>.</p>
             <p>Best,<br>TigerSnatch Team <3</p>
         </body>
-        </html>
-        """
+        </html>"""
 
         message = Mail(
             from_email=TS_EMAIL,

--- a/views/tutorial.html
+++ b/views/tutorial.html
@@ -70,7 +70,7 @@
       <div class="row">
         <p class="fw-light text-center mt-4 fs-5 tutorial-text">
           It's that simple! The next time a spot opens up in a subscribed section, you'll be
-          notified immediately via email. You'll continue receiving notifications every 2 minutes
+          notified immediately via email. You'll continue receiving notifications every 5 minutes
           until that section is full again, or you unsubscribe from it. To unsubscribe from a
           section, simply toggle the section's switch off in the Dashboard.
         </p>


### PR DESCRIPTION
In order to preserve SendGrid emails, we decided to decrease the notification frequency to once every 5 minutes (down from once every 2 minutes). Accordingly, this PR updates the wording in the Tutorial, README, and email notification.

![image](https://user-images.githubusercontent.com/13815069/130541475-523991d7-67da-4972-b9b3-c50f4f5d35d2.png)

This PR also removes unused Trades code in `notify.py`.