### PR TITLE
Course updater script optimization

### DIFF
--- a/src/_exec_update_all_courses.py
+++ b/src/_exec_update_all_courses.py
@@ -68,13 +68,13 @@ def do_update(reset_type):
     db.set_maintenance_status(False)
 
     db._add_admin_log(
-        f"updated to term code {current_term_code} in {round(time()-tic)} seconds ({n_courses} courses, {n_classes} sections)"
+        f"{'hard' if hard_reset else 'soft'}-updated to term code {current_term_code} in {round(time()-tic)} seconds ({n_courses} courses, {n_classes} sections)"
     )
 
     db._add_system_log(
         "admin",
         {
-            "message": f"updated to term code {current_term_code} in {round(time()-tic)} seconds ({n_courses} courses, {n_classes} sections)"
+            "message": f"{'hard' if hard_reset else 'soft'}-updated to term code {current_term_code} in {round(time()-tic)} seconds ({n_courses} courses, {n_classes} sections)"
         },
         netid="SYSTEM_AUTO",
     )

--- a/src/_exec_update_all_courses.py
+++ b/src/_exec_update_all_courses.py
@@ -27,7 +27,7 @@ from database import Database
 from sys import argv, exit
 from time import time
 from os import system
-from update_all_courses_utils import get_all_dept_codes, process_dept_code
+from update_all_courses_utils import get_all_dept_codes, process_dept_codes
 
 
 # True --> hard reset
@@ -62,33 +62,19 @@ def do_update(reset_type):
     )
     print(f"getting all courses in term code {current_term_code}")
 
-    DEPT_CODES = get_all_dept_codes(current_term_code)
-
-    # process_dept_code_args = []
-    for n, code in enumerate(DEPT_CODES):
-        process_dept_code([code, n, current_term_code, False, hard_reset])
-        # the below code is for multiprocessing
-        # process_dept_code_args.append(
-        #     [code, n, current_term_code, True, hard_reset])
-
-    # alleviate MobileApp bottleneck using multiprocessing
-    # NOTE: setting cores to > 1 yields in different results every time
-    # replace with cpu_count() if someone figures out why - it's not a
-    # big issue though because this script is run only once per semester
-
-    # with Pool(1) as pool:
-    #     pool.map(process_dept_code, process_dept_code_args)
+    DEPT_CODES = ",".join(get_all_dept_codes(current_term_code))
+    n_courses, n_classes = process_dept_codes(DEPT_CODES, current_term_code, hard_reset)
 
     db.set_maintenance_status(False)
 
     db._add_admin_log(
-        f"updated to term code {current_term_code} in {round(time()-tic)} seconds"
+        f"updated to term code {current_term_code} in {round(time()-tic)} seconds ({n_courses} courses, {n_classes} sections)"
     )
 
     db._add_system_log(
         "admin",
         {
-            "message": f"updated to term code {current_term_code} in {round(time()-tic)} seconds"
+            "message": f"updated to term code {current_term_code} in {round(time()-tic)} seconds ({n_courses} courses, {n_classes} sections)"
         },
         netid="SYSTEM_AUTO",
     )

--- a/src/update_all_courses_utils.py
+++ b/src/update_all_courses_utils.py
@@ -42,13 +42,11 @@ def process_dept_codes(dept_codes: str, current_term_code: str, hard_reset: bool
             db.soft_reset_db()
 
         n_courses = 0
-        n_classes = 0
+        n_sections = 0
 
         # iterate through all subjects, courses, and classes
         for subject in courses["term"][0]["subjects"]:
-            print("-------------------------")
-            print("processing dept code", subject["code"])
-            print("-------------------------")
+            print("> processing dept code", subject["code"])
             for course in subject["courses"]:
                 courseid = course["course_id"]
                 if db.courses_contains_courseid(courseid):
@@ -155,7 +153,7 @@ def process_dept_codes(dept_codes: str, current_term_code: str, hard_reset: bool
                     else:
                         all_new_classes.append(new_class)
 
-                    n_classes += 1
+                    n_sections += 1
 
                 for i, new_class in enumerate(all_new_classes):
                     new[f'class_{new_class["classid"]}'] = new_class
@@ -165,10 +163,9 @@ def process_dept_codes(dept_codes: str, current_term_code: str, hard_reset: bool
 
                 n_courses += 1
 
-        print("-------------------------")
-        print("processed", n_courses, "courses and", n_classes, "classes")
-        print("-------------------------")
-        return n_courses, n_classes
+        print(f"> processed {n_courses} courses and {n_sections} sections")
+        print(f"> performed a {'hard' if hard_reset else 'soft'} reset")
+        return n_courses, n_sections
 
     except Exception as e:
         print(f"failed to get new course data with exception message {e}", file=stderr)

--- a/src/update_all_courses_utils.py
+++ b/src/update_all_courses_utils.py
@@ -6,7 +6,6 @@
 
 from mobileapp import MobileApp
 from database import Database
-from random import random
 from sys import stderr
 import time
 
@@ -28,33 +27,28 @@ def get_all_dept_codes(term):
     return codes
 
 
-# helper method for multiprocessing: fetches and inserts new course
-# information into the database
-def process_dept_code(args):
+# fetches and inserts new course information into the database
+def process_dept_codes(dept_codes: str, current_term_code: str, hard_reset: bool):
     try:
-        code, n, current_term_code, dummy_waitlists, hard_reset = (
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-        )
         db = Database()
-
-        print("processing dept code", code)
-        courses = _api.get_courses(term=current_term_code, subject=code)
+        courses = _api.get_courses(term=current_term_code, subject=dept_codes)
 
         if "subjects" not in courses["term"][0]:
             raise RuntimeError("no query results")
 
-        if n == 0:
-            if hard_reset:
-                db.reset_db()
-            else:
-                db.soft_reset_db()
+        if hard_reset:
+            db.reset_db()
+        else:
+            db.soft_reset_db()
+
+        n_courses = 0
+        n_classes = 0
 
         # iterate through all subjects, courses, and classes
         for subject in courses["term"][0]["subjects"]:
+            print("-------------------------")
+            print("processing dept code", subject["code"])
+            print("-------------------------")
             for course in subject["courses"]:
                 courseid = course["course_id"]
                 if db.courses_contains_courseid(courseid):
@@ -161,21 +155,7 @@ def process_dept_code(args):
                     else:
                         all_new_classes.append(new_class)
 
-                    ####################################################
-
-                    # randomly add waitlists for testing purposes
-                    rand = random()
-                    if dummy_waitlists and rand < 0.005:
-                        print("> inserting", classid, "into waitlists")
-                        db.add_to_waitlist("sheh", classid, disable_checks=True)
-                    elif dummy_waitlists and 0.005 <= rand < 0.01:
-                        print("> inserting", classid, "into waitlists")
-                        db.add_to_waitlist("ntyp", classid, disable_checks=True)
-                    elif dummy_waitlists and 0.01 <= rand < 0.015:
-                        print("> inserting", classid, "into waitlists")
-                        db.add_to_waitlist("zishuoz", classid, disable_checks=True)
-
-                    ####################################################
+                    n_classes += 1
 
                 for i, new_class in enumerate(all_new_classes):
                     new[f'class_{new_class["classid"]}'] = new_class
@@ -183,7 +163,13 @@ def process_dept_code(args):
                 print("inserting", new["displayname"], "into courses")
                 db.add_to_courses(new)
 
-        print()
+                n_courses += 1
+
+        print("-------------------------")
+        print("processed", n_courses, "courses and", n_classes, "classes")
+        print("-------------------------")
+        return n_courses, n_classes
 
     except Exception as e:
-        print(f"failed on code {args[0]} with exception message {e}", file=stderr)
+        print(f"failed to get new course data with exception message {e}", file=stderr)
+        return 0, 0


### PR DESCRIPTION
Currently, the course updater script makes 1 MobileApp API call per department code, namely by setting the query `subject=<dept code>`. I was told by OIT that we can optimize this by passing a comma-separated list of department codes such as `subject=AMS,COS,ECE,WRI` and the API will return all courses corresponding to at least one of those codes. We can use this functionality by passing all ~120 department codes and getting back all courses at once. This way, we can make just 1 API call overall, which should decrease the script's running time. The key change is (new) line 34 in `src/update_all_courses_utils.py`.

I tested the functionality of passing multiple department codes by calling `api.get_courses(term="1214", subject="AMS,COS,WRI")` in `mobileapp.py` and checking that the response contains courses from AMS, COS, and WRI (which are non-overlapping).

To fully test the change, I ran

```
$ heroku run python src/_exec_update_all_courses.py --soft -a tigersnatch-pr-25
```

and made sure that the database `courses` collection contains 1254 courses (the same as before).