### PR TITLE
Mass email script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode
 *.pyc
 .DS_Store
+SUBJECT
+MESSAGE

--- a/src/_email_all_users.py
+++ b/src/_email_all_users.py
@@ -4,35 +4,23 @@
 # make sure that all environment variables are already set. See Heroku
 # Config Vars to get these variables.
 #
-# Note: Please don't commit your custom subject and message!
-#
 # Script to email all TigerSnatch users. This uses a SendGrid dynamic
-# template (edit on SendGrid --> Dynamic Templates). To use this script,
-# set the variable MESSAGE (can include new-line characters and HTML tags)
-# to the body of the email you'd like to send, and SUBJECT to the subject.
-# Then, execute the script. Always test your email by sending it to admins
-# with --test, before sending it to everyone with --all!
+# template (edit on SendGrid --> Dynamic Templates). To use this script:
 #
-# Specify one of the following flags:
-#   --test: Send email to only admins
-# 	--all: Send email to all users
+# 1. Create a file named MESSAGE in the same directory as this script
+#    and type the body of your email (can include new-lines and HTML
+#    tags).
+# 2. Create a file named SUBJECT in the same directory as this script
+#    and type the subject of your email (must be on a single line,
+#    without any HTML tags).
+# 3. Execute the script. Always test your email by first sending it to
+#    admins with --test, before sending it to everyone with --all!
 #
-# Example: python _email_all_users.py --test
-# ----------------------------------------------------------------------
-
-# set the email subject exactly as you want it displayed
-SUBJECT = "Your subject goes here!"
-
-# set the email message exactly as you want it displayed (leave the leading
-# and trailing new-lines). you may use HTML tags and new-line characters!
-# note: the email template already has "Greetings" at the beginning
-# and "~ TigerSnatch Team" at the end
-MESSAGE = """
-Your <b><a href="https://tigersnatch.com">message</a></b> goes here!
-
-You can use multiple lines if necessary.
-"""
-
+#    Specify one of the following flags:
+#       --test: Send email to only admins
+# 	    --all: Send email to all users
+#
+#    Example: python _email_all_users.py --test
 # ----------------------------------------------------------------------
 
 from database import Database
@@ -49,6 +37,14 @@ if __name__ == "__main__":
             print("\t--all: send email to ALL users")
             exit(2)
         return argv[1] == "--all"
+
+    DIR = "/".join(__file__.split("/")[:-1])
+    SUBJECT_FILEPATH = f"{DIR}/SUBJECT"
+    MESSAGE_FILEPATH = f"{DIR}/MESSAGE"
+
+    with open(SUBJECT_FILEPATH, "r") as subj, open(MESSAGE_FILEPATH, "r") as msg:
+        SUBJECT = subj.read()
+        MESSAGE = msg.read()
 
     send_to_all_users = process_args()
     send_to_admins = not send_to_all_users

--- a/src/_email_all_users.py
+++ b/src/_email_all_users.py
@@ -7,20 +7,21 @@
 # Script to email all TigerSnatch users. This uses a SendGrid dynamic
 # template (edit on SendGrid --> Dynamic Templates). To use this script:
 #
-# 1. Create a file named MESSAGE in the same directory as this script
-#    and type the body of your email (can include new-lines and HTML
-#    tags).
-# 2. Create a file named SUBJECT in the same directory as this script
-#    and type the subject of your email (must be on a single line,
-#    without any HTML tags).
+# 1. Create a file named MESSAGE (no extension) in the same directory as
+#    this script and type the body of your email (can include new-lines
+#    and HTML tags).
+# 2. Create a file named SUBJECT (no extension) in the same directory as
+#    this script and type the subject of your email (must be on a single
+#    line, without any HTML tags).
 # 3. Execute the script. Always test your email by first sending it to
 #    admins with --test, before sending it to everyone with --all!
 #
 #    Specify one of the following flags:
-#       --test: Send email to only admins
-# 	    --all: Send email to all users
+#       --test <email1> <email2> ... : Send to 1+ specific emails.
+# 	    --all: Send to ALL user emails.
 #
-#    Example: python _email_all_users.py --test
+#    Example: python _email_all_users.py --test x@x.com y@y.com
+#    Example: python _email_all_users.py --all
 # ----------------------------------------------------------------------
 
 from database import Database
@@ -31,10 +32,10 @@ from config import SENDGRID_API_KEY, TS_EMAIL
 if __name__ == "__main__":
 
     def process_args():
-        if len(argv) != 2 or (argv[1] != "--test" and argv[1] != "--all"):
+        if len(argv) < 2 or (argv[1] != "--test" and argv[1] != "--all"):
             print("specify one of the following flags:")
-            print("\t--test: send email to only admins")
-            print("\t--all: send email to ALL users")
+            print("\t--test <email1> <email2> ...: send to 1+ specific emails")
+            print("\t--all: send to ALL user emails")
             exit(2)
         return argv[1] == "--all"
 
@@ -42,23 +43,33 @@ if __name__ == "__main__":
     SUBJECT_FILEPATH = f"{DIR}/SUBJECT"
     MESSAGE_FILEPATH = f"{DIR}/MESSAGE"
 
-    with open(SUBJECT_FILEPATH, "r") as subj, open(MESSAGE_FILEPATH, "r") as msg:
-        SUBJECT = subj.read()
-        MESSAGE = msg.read()
+    try:
+        with open(SUBJECT_FILEPATH, "r") as subj, open(MESSAGE_FILEPATH, "r") as msg:
+            SUBJECT = subj.read()
+            MESSAGE = msg.read()
+    except FileNotFoundError:
+        print("make sure that files SUBJECT and MESSAGE (no extensions) exist in /src!")
+        exit(1)
 
     send_to_all_users = process_args()
-    send_to_admins = not send_to_all_users
-    db = Database()
-    emails = (
-        db._get_all_emails_csv() if send_to_all_users else db._get_admin_emails_csv()
-    ).split(",")
+    send_to_custom = not send_to_all_users
+
+    if send_to_custom and len(argv) < 3:
+        print("--test requires a space-separated list of 1+ email addresses!")
+        print("Example: $ python _email_all_users.py --test x@x.com y@y.com")
+        exit(1)
+
+    if send_to_all_users:
+        emails = Database()._get_all_emails_csv().split(",")
+    else:
+        emails = argv[2:]
 
     SUBJECT = SUBJECT.strip()
     MESSAGE = MESSAGE.strip().replace("\n", "<br>")
 
-    if send_to_admins:
+    if send_to_custom:
         SUBJECT = f"[Test] {SUBJECT}"
-        MESSAGE = f"[This is a test email sent to TigerSnatch admins only]<br>{MESSAGE}"
+        MESSAGE = f"[This is a test email]<br>{MESSAGE}"
 
     print("---------------")
     print("SUBJECT:", SUBJECT)
@@ -69,7 +80,7 @@ if __name__ == "__main__":
     print()
     if (
         input(
-            f"Send the above email to {'ALL users' if send_to_all_users else 'admins only'} ({len(emails)} in total)? (y/n) "
+            f"Send the above email to {'ALL users' if send_to_all_users else argv[2:]} ({len(emails)} in total)? (y/n) "
         )
         != "y"
     ):

--- a/src/_email_all_users.py
+++ b/src/_email_all_users.py
@@ -1,0 +1,99 @@
+# ----------------------------------------------------------------------
+# _email_all_users.py
+# Note: It is best to run this script *on your local computer*. You must
+# make sure that all environment variables are already set. See Heroku
+# Config Vars to get these variables.
+#
+# Note: Please don't commit your custom subject and message!
+#
+# Script to email all TigerSnatch users. This uses a SendGrid dynamic
+# template (edit on SendGrid --> Dynamic Templates). To use this script,
+# set the variable MESSAGE (can include new-line characters and HTML tags)
+# to the body of the email you'd like to send, and SUBJECT to the subject.
+# Then, execute the script. Always test your email by sending it to admins
+# with --test, before sending it to everyone with --all!
+#
+# Specify one of the following flags:
+#   --test: Send email to only admins
+# 	--all: Send email to all users
+#
+# Example: python _email_all_users.py --test
+# ----------------------------------------------------------------------
+
+# set the email subject exactly as you want it displayed
+SUBJECT = "Your subject goes here!"
+
+# set the email message exactly as you want it displayed (leave the leading
+# and trailing new-lines). you may use HTML tags and new-line characters!
+# note: the email template already has "Greetings" at the beginning
+# and "~ TigerSnatch Team" at the end
+MESSAGE = """
+Your <b><a href="https://tigersnatch.com">message</a></b> goes here!
+
+You can use multiple lines if necessary.
+"""
+
+# ----------------------------------------------------------------------
+
+from database import Database
+from sys import exit, argv
+from sendgrid import SendGridAPIClient
+from config import SENDGRID_API_KEY, TS_EMAIL
+
+if __name__ == "__main__":
+
+    def process_args():
+        if len(argv) != 2 or (argv[1] != "--test" and argv[1] != "--all"):
+            print("specify one of the following flags:")
+            print("\t--test: send email to only admins")
+            print("\t--all: send email to ALL users")
+            exit(2)
+        return argv[1] == "--all"
+
+    send_to_all_users = process_args()
+    send_to_admins = not send_to_all_users
+    db = Database()
+    emails = (
+        db._get_all_emails_csv() if send_to_all_users else db._get_admin_emails_csv()
+    ).split(",")
+
+    SUBJECT = SUBJECT.strip()
+    MESSAGE = MESSAGE.strip().replace("\n", "<br>")
+
+    if send_to_admins:
+        SUBJECT = f"[Test] {SUBJECT}"
+        MESSAGE = f"[This is a test email sent to TigerSnatch admins only]<br>{MESSAGE}"
+
+    print("---------------")
+    print("SUBJECT:", SUBJECT)
+    print()
+    print("MESSAGE:")
+    print(MESSAGE.replace("<br>", "\n"))
+    print("---------------")
+    print()
+    if (
+        input(
+            f"Send the above email to {'ALL users' if send_to_all_users else 'admins only'} ({len(emails)} in total)? (y/n) "
+        )
+        != "y"
+    ):
+        print("Exiting...")
+        exit(0)
+
+    print("Sending... ", end="")
+
+    data = {
+        "personalizations": [
+            {
+                "to": [{"email": email}],
+                "dynamic_template_data": {"subject": SUBJECT, "message": MESSAGE},
+            }
+            for email in emails
+        ],
+        "from": {"email": TS_EMAIL, "name": "TigerSnatch"},
+        "template_id": "d-e688d68d1bac424382aa8535026d6f36",
+    }
+
+    SendGridAPIClient(SENDGRID_API_KEY).client.mail.send.post(request_body=data)
+
+    print(f"{len(emails)} emails sent!")

--- a/src/database.py
+++ b/src/database.py
@@ -1658,13 +1658,6 @@ class Database:
         emails = [k["email"] for k in data]
         return ",".join(emails)
 
-    def _get_admin_emails_csv(self):
-        data = self._db.admin.find_one({}, {"_id": 0, "admins": 1})
-        emails = data["admins"]
-        if len(emails) == 0:
-            return ""
-        return "@princeton.edu,".join(emails) + "@princeton.edu"
-
     # checks that all required collections are available in self._db;
     # raises a RuntimeError if not
 

--- a/src/database.py
+++ b/src/database.py
@@ -1658,6 +1658,13 @@ class Database:
         emails = [k["email"] for k in data]
         return ",".join(emails)
 
+    def _get_admin_emails_csv(self):
+        data = self._db.admin.find_one({}, {"_id": 0, "admins": 1})
+        emails = data["admins"]
+        if len(emails) == 0:
+            return ""
+        return "@princeton.edu,".join(emails) + "@princeton.edu"
+
     # checks that all required collections are available in self._db;
     # raises a RuntimeError if not
 


### PR DESCRIPTION
## Goal
- Create an email script that can send HTML-formatted (e.g. `<img>`, `<b>`, `<a>`) emails to all TigerSnatch users.
    - Also provide the ability to send a "test" email to only admins, in order to check formatting etc.
- Use a SendGrid template to make mass emails look nicer.
- Remove the need to use Outlook in combination with manually getting chunks of 500 users to send TigerSnatch emails.

## Functionality
- Use `--test` to send the email to only admins as listed in the admin collection.
- Use `--all` to send the email to all users.

## Testing
- Set the database URL to the dev database to avoid emailing 2500 people.
- Create files `SUBJECT` and `MESSAGE` in the same directory as the script. Type an email subject in `SUBJECT` and an email body in `MESSAGE`.
- Run `python src/_email_all_users.py --test` and follow the prompts. Check your email (if you're an admin) to verify it's how you want.
- Run `python src/_email_all_users.py --all` and follow the prompts.

## Example run
```
$ python src/_email_all_users.py --all
---------------
SUBJECT: Your subject goes here!

MESSAGE:
Your <b><a href="https://tigersnatch.com">message</a></b> goes here!

You can use multiple lines if necessary.
---------------

Send the above email to ALL users (2 in total)? (y/n) y
Sending... 2 emails sent!
```

This is what emails to only admins (`--test` flag) look like (doesn't have a hyperlink in it because it's an older screenshot):

<img width="979" alt="image" src="https://user-images.githubusercontent.com/13815069/149642816-f6bc9424-d29f-4c76-8b5b-72ebc4392e1c.png">

This is what emails to all users (`--all` flag) look like:

<img width="978" alt="image" src="https://user-images.githubusercontent.com/13815069/149642829-5a68cdbf-c130-4715-9498-ecd1d2195bef.png">
