### PR TITLE
Reduce duplicate notifs for auto-resubbed users

### DIFF
--- a/src/monitor.py
+++ b/src/monitor.py
@@ -113,8 +113,13 @@ class Monitor:
             if course is None:
                 continue
 
+            # class_ is classid
             for class_, n_slots in course.get_available_slots().items():
                 data[class_] = n_slots
+                # cover edge case where the number of open spots is 0 (not covered in Notify)
+                # prevent updating times of last notif by passing [] as netids
+                if n_slots == 0:
+                    self._db.update_users_notifs_history([], class_, 0)
 
         self._changed_enrollments = data
         print(f"success: approx. {round(time()-tic)} seconds")

--- a/views/utils/user_settings.html
+++ b/views/utils/user_settings.html
@@ -86,7 +86,7 @@
 
                     <div class="row"
                          id="auto-resub-row">
-                        <div class="input-group mb-2">
+                        <div class="input-group mb-1">
                             <div class="input-group-text">
                                 <svg xmlns="http://www.w3.org/2000/svg"
                                      width="24"
@@ -128,6 +128,9 @@
                                 </div>
                                 {% endif %}
                             </div>
+                        </div>
+                        <div class="form-text mt-0" style="line-height: 1.3;">
+                            To reduce spam for users who choose to stay subscribed, TigerSnatch sends notifications less often if the number of open spots for a section doesn’t change.
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
# Goals
- Previously, for auto resubbed users, notifications would be repeatedly sent as long as there were open spots. This would result in excessive spam for these users and extreme costs for TigerSnatch to send emails/texts.
- Now, for auto resubbed users, notifications are sent for a section only if the number of open spots has changed since the last notification was sent (for that user), OR if it has been more than a fixed amount of time (currently 30 mins) since the last notification was sent. 
- This change improves the user experience by reducing email/txt spam for users. It allows TigerSnatch to frequently check for open spots without having to worry about the financial viability of maintaining our app. 

# Major Changes
- New `notifs` collection (one document for each user)
- New database methods
- Handled main logic in `notify.py` and edge case (zero open spots) in `monitor.py`
- Added helper text to settings modal
- Added new env variable `MIN_NOTIFS_DELAY_MINS` (in previous commit)

# Testing 
- Filled course with available spots. Simulated the following cases by running notifs script (for 1+ auto-resubbed user):
    - `< 30` mins passed since last notif AND number of open spots has changed --> notifs sent 
    - `>= 30` mins passed since last notif AND number of open spots has changed --> notifs sent 
    - `>= 30` mins passed since last notif AND number of open spots not changed --> notifs sent
    - `< 30` mins passed since last notif AND number of open spots not changed --> notifs NOT sent
- Whenever notifs are sent, check that time of last notif in DB was updated.
- Number of open spots is always updated.
- For auto-unsubbed users, check that they're unsubbed (above logic doesn't apply)
- For reserved courses, check that above logic doesn't apply.