### PR TITLE
Small fixes for PR #33

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -18,7 +18,8 @@ from config import (
 from schema import COURSES_SCHEMA, CLASS_SCHEMA, MAPPINGS_SCHEMA, ENROLLMENTS_SCHEMA
 from pymongo import MongoClient
 from pymongo.errors import ConnectionFailure
-from datetime import datetime
+from datetime import datetime, timedelta
+from random import randint
 import pytz
 import heroku3
 
@@ -1031,9 +1032,14 @@ class Database:
         )
 
         # update last_notif for only users who received notifs (i.e. netids)
+        # add or subtract a random small amount of time to help spread out notifs
+        RAND_OFFSET_MINS = 5
+        new_last_notif = datetime.now(TZ) + timedelta(
+            minutes=randint(-RAND_OFFSET_MINS, RAND_OFFSET_MINS)
+        )
         self._db.notifs.update_many(
             {"netid": {"$in": netids}, classid: {"$exists": True}},
-            {"$set": {f"{classid}.last_notif": datetime.now(TZ)}},
+            {"$set": {f"{classid}.last_notif": new_last_notif}},
         )
 
     # ----------------------------------------------------------------------

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -116,10 +116,6 @@ class Monitor:
             # class_ is classid
             for class_, n_slots in course.get_available_slots().items():
                 data[class_] = n_slots
-                # cover edge case where the number of open spots is 0 (not covered in Notify)
-                # prevent updating times of last notif by passing [] as netids
-                if n_slots == 0:
-                    self._db.update_users_notifs_history([], class_, 0)
 
         self._changed_enrollments = data
         print(f"success: approx. {round(time()-tic)} seconds")

--- a/src/send_notifs.py
+++ b/src/send_notifs.py
@@ -40,6 +40,8 @@ def cronjob():
     n_sections = 0
     for classid, n_new_slots in new_slots.items():
         if n_new_slots == 0:
+            # cover edge case where the number of open spots is 0 (not covered in Notify)
+            db.update_users_notifs_history([], classid, 0)
             continue
 
         try:


### PR DESCRIPTION
## Goals
- Improve code organization by keeping together code blocks with similar purpose (credit - @shannon-heh)
- Prevent spike in notifications every 30 mins (caused by the initial mass-population of the `notifs` collection all at once) by adding or subtracting up to 5 minutes from the to-be-inserted time of last notif

## Testing
### New placement of 0 open-spot edge case
- Subscribe to an actual full section
- In the `notifs` collection, manually set `n_open_spots` for the section's classID to a non-zero integer
- Run `send_notifs.py` and check that `n_open_spots` is set to 0

### +- 5 minute offset
- Manually fill a section and subscribe to it
- Run `send_notifs.py` once to update `n_open_spots` and `last_notif` in the `notifs` collection for the section's classID
- Manually change `n_open_spots` to something different, and rerun `send_notifs.py` (notifs will be sent for this section)
- Check that the new `last_notif` time is set to +- 5 minutes from the current time (may have to repeat this step and the last a couple times in case the random offset is 0)
- Manually change `last_notif` to be more than 30 minutes ago, and rerun `send_notifs.py` (again, notifs will be sent for this section)
- Check that the new `last_notif` time is set to +- 5 minutes from the current time (again, may have to repeat this step and the last a couple times in case the random offset is 0)

I followed this test plan to verify that the changes work.