### PR TITLE
Skip classes in notifs script whose status is not "Open"

### DIFF
--- a/src/mobileapp.py
+++ b/src/mobileapp.py
@@ -95,7 +95,7 @@ class Configs:
     def __init__(self):
         self.CONSUMER_KEY = CONSUMER_KEY
         self.CONSUMER_SECRET = CONSUMER_SECRET
-        self.BASE_URL = "https://api.princeton.edu:443/mobile-app/1.0.3"
+        self.BASE_URL = "https://api.princeton.edu:443/mobile-app/1.0.4"
         self.COURSE_SEATS = "/courses/seats"
         self.COURSE_COURSES = "/courses/courses"
         self.COURSE_TERMS = "/courses/terms"

--- a/src/monitor_utils.py
+++ b/src/monitor_utils.py
@@ -59,6 +59,12 @@ def get_new_mobileapp_data(
             # skip classids that people are not subscribed to
             if classid not in classids:
                 continue
+            # skip classes whose status is not "Open" (enrollment is not possible)
+            if class_["pu_calc_status"] != "Open":
+                print(
+                    f"class {classid} in course {courseid} skipped: status is {class_['pu_calc_status']}"
+                )
+                continue
             if courseid not in new_enroll:
                 new_enroll[courseid] = {}
                 new_cap[courseid] = {}


### PR DESCRIPTION
Thanks to changes by OIT, TigerSnatch is finally able to determine the official enrollment status of a section (Open, Closed, or Canceled) as shown on the official Course Offerings website. If seats free up in a Subscribed section, users will be notified only if that section is Open.

Specifically, the field `pu_calc_status` was added into `/courses/seats` within each class object. This field's value is Open, Closed, or Canceled.

We should send an email to all users with something like this:
> Thanks to changes by Princeton's IT department, TigerSnatch is finally able to determine a section's official enrollment status (Open, Closed, or Canceled). If seats free up in one of your Subscribed sections, you will be notified only if that section is Open. Note that for sections with reserved seating, it is still impossible to determine whether an open spot corresponds to a particular reserved seat category.