### PR TITLE
Fix JSONDecodeError when Active Directory API returns empty response

### DIFF
--- a/src/activedirectory.py
+++ b/src/activedirectory.py
@@ -56,7 +56,14 @@ class ActiveDirectory:
         # Check to see if the response failed due to invalid credentials
         text = self._updateConfigs(text, endpoint, **kwargs)
 
-        return json.loads(text)
+        # Handle empty or invalid JSON responses from the API
+        if not text or not text.strip():
+            return None
+
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return None
 
     def _updateConfigs(self, text, endpoint, **kwargs):
         if text.startswith("<ams:fault"):


### PR DESCRIPTION
## Summary
- Fixes crash when new users try to sign up and the Princeton Active Directory API returns an empty response
- Adds proper error handling to `_getJSON()` in `activedirectory.py` to gracefully handle empty or invalid JSON responses
- Users can now sign up with `year=None` instead of the app crashing

## Problem
When a new user logs in for the first time, the app calls `create_user()` which calls `get_year()` to fetch the user's class year from Princeton's Active Directory API. If the API returns an empty response, `json.loads("")` throws:
```
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## Solution
Added null checks and try-except handling around `json.loads()` to return `None` instead of crashing when the API returns empty or invalid JSON.

## Test plan
- [x] Test new user signup when Active Directory API is working
- [x] Verify existing users can still log in normally

Resolves TIG-20
_(PR message authored by Codex)_