### PR TITLE
(fix) harden notification schedule recovery

### DIFF
--- a/send_notifs_cron.py
+++ b/send_notifs_cron.py
@@ -11,7 +11,7 @@ from sys import path
 
 path.append("src")  # noqa
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from sys import stderr
 
 import pytz
@@ -30,96 +30,160 @@ from log_utils import *
 from send_notifs import *
 
 
-def schedule_jobs(update_db=False):
+def _should_notify_admins_of_schedule_change(times):
+    return AUTO_GENERATE_NOTIF_SCHEDULE and len(times) > 0
+
+
+def _persist_notifs_schedule_if_changed(times):
     try:
-        sched = BackgroundScheduler()
-        times = generate_time_intervals()
+        if not did_notifs_spreadsheet_change(times):
+            return False
+
+        update_notifs_schedule(times)
+
+        if _should_notify_admins_of_schedule_change(times):
+            notify_admins_of_schedule_change(times)
+        elif len(times) == 0:
+            log_warning(
+                "Stored empty notifications schedule without sending schedule update email"
+            )
+
+        return True
+    except Exception as e:
+        log_error("Failed to persist notifications schedule update")
+        print(e, file=stderr)
+        return False
+
+
+def _build_scheduler(times):
+    sched = BackgroundScheduler()
+    tz = pytz.timezone("US/Eastern")
+    active_notifs_window = False
+
+    log_cron("Adding global soft course update job at 4am ET daily")
+    sched.add_job(
+        do_update_async_SOFT,
+        "cron",
+        hour="4",
+        timezone=tz,
+    )
+
+    log_cron("Adding global soft course update job at 5am ET daily")
+    sched.add_job(
+        do_update_async_SOFT,
+        "cron",
+        hour="5",
+        timezone=tz,
+    )
+
+    log_cron("Adding stats update job every 10 mins")
+    sched.add_job(
+        update_stats,
+        "interval",
+        minutes=STATS_INTERVAL_MINS,
+    )
+
+    log_cron(
+        f"Adding global hard course update job every {GLOBAL_COURSE_UPDATE_INTERVAL_MINS} mins"
+    )
+    sched.add_job(
+        do_update_async_HARD,
+        "interval",
+        minutes=GLOBAL_COURSE_UPDATE_INTERVAL_MINS,
+    )
+
+    for i, time in enumerate(times):
+        start, end = time[0], time[1]
+        log_cron(f"Adding notifs job between {start} and {end}")
+        sched.add_job(
+            cronjob,
+            "interval",
+            start_date=start,
+            end_date=end
+            - timedelta(seconds=1),  # subtract 1 second to prevent run at closing time
+            timezone=tz,
+            seconds=NOTIFS_INTERVAL_SECS,
+            max_instances=1,
+            id=str(i),
+            args=[end - timedelta(seconds=NOTIFS_INTERVAL_SECS)],
+        )
+        log_cron(f"Adding live notifs countdown job between {start} and {end}")
+        sched.add_job(
+            update_live_notifs_countdown,
+            "interval",
+            start_date=start,
+            end_date=end
+            - timedelta(
+                seconds=NOTIFS_INTERVAL_SECS  # subtract NOTIFS_INTERVAL_SECS seconds to prevent weird edge cases at closing time
+            ),
+            timezone=tz,
+            seconds=1,
+            args=[sched.get_job(str(i))],
+        )
+        sched.add_job(
+            set_status_indicator_to_on,
+            "date",
+            run_date=start,
+            timezone=tz,
+        )
+        sched.add_job(
+            set_status_indicator_to_off,
+            "date",
+            run_date=end,
+            timezone=tz,
+        )
+        if start <= datetime.now(tz) <= end:
+            active_notifs_window = True
+
+    return sched, active_notifs_window
+
+
+def _sync_status_indicator(active_notifs_window):
+    set_status_indicator_to_off(log=False)
+    if active_notifs_window:
+        set_status_indicator_to_on()
+
+
+def _start_scheduler(sched):
+    log_cron("Booting notifs scheduler")
+    sched.start()
+    log_cron("Done booting notifs scheduler")
+
+
+def _shutdown_scheduler(sched):
+    if sched is None:
+        log_warning("No current notifs scheduler was running")
+        return True
+
+    if hasattr(sched, "running") and not sched.running:
+        log_warning("Current notifs scheduler was already stopped")
+        return True
+
+    try:
+        sched.shutdown()
+        return True
+    except Exception as e:
+        log_error("Failed to shut down current notifs scheduler")
+        print(e, file=stderr)
+        return False
+
+
+def _replace_scheduler(scheds, new_sched):
+    scheds[:] = [new_sched]
+
+
+def schedule_jobs(update_db=False, times=None):
+    try:
+        if times is None:
+            times = generate_time_intervals()
+
+        sched, active_notifs_window = _build_scheduler(times)
+        _sync_status_indicator(active_notifs_window)
+        _start_scheduler(sched)
+
         if update_db:
-            if did_notifs_spreadsheet_change(times):
-                notify_admins_of_schedule_change(times)
-            update_notifs_schedule(times)  # update database
-        set_status_indicator_to_off(log=False)
-        tz = pytz.timezone("US/Eastern")
+            _persist_notifs_schedule_if_changed(times)
 
-        log_cron("Adding global soft course update job at 4am ET daily")
-        sched.add_job(
-            do_update_async_SOFT,
-            "cron",
-            hour="4",
-            timezone=tz,
-        )
-
-        log_cron("Adding global soft course update job at 5am ET daily")
-        sched.add_job(
-            do_update_async_SOFT,
-            "cron",
-            hour="5",
-            timezone=tz,
-        )
-
-        log_cron("Adding stats update job every 10 mins")
-        sched.add_job(
-            update_stats,
-            "interval",
-            minutes=STATS_INTERVAL_MINS,
-        )
-
-        log_cron(
-            f"Adding global hard course update job every {GLOBAL_COURSE_UPDATE_INTERVAL_MINS} mins"
-        )
-        sched.add_job(
-            do_update_async_HARD,
-            "interval",
-            minutes=GLOBAL_COURSE_UPDATE_INTERVAL_MINS,
-        )
-
-        for i, time in enumerate(times):
-            start, end = time[0], time[1]
-            log_cron(f"Adding notifs job between {start} and {end}")
-            sched.add_job(
-                cronjob,
-                "interval",
-                start_date=start,
-                end_date=end
-                - timedelta(
-                    seconds=1  # subtract 1 second to prevent run at closing time
-                ),
-                timezone=tz,
-                seconds=NOTIFS_INTERVAL_SECS,
-                max_instances=1,
-                id=str(i),
-                args=[end - timedelta(seconds=NOTIFS_INTERVAL_SECS)],
-            )
-            log_cron(f"Adding live notifs countdown job between {start} and {end}")
-            sched.add_job(
-                update_live_notifs_countdown,
-                "interval",
-                start_date=start,
-                end_date=end
-                - timedelta(
-                    seconds=NOTIFS_INTERVAL_SECS  # subtract NOTIFS_INTERVAL_SECS seconds to prevent weird edge cases at closing time
-                ),
-                timezone=tz,
-                seconds=1,
-                args=[sched.get_job(str(i))],
-            )
-            sched.add_job(
-                set_status_indicator_to_on,
-                "date",
-                run_date=start,
-                timezone=tz,
-            )
-            sched.add_job(
-                set_status_indicator_to_off,
-                "date",
-                run_date=end,
-                timezone=tz,
-            )
-            if start <= datetime.now(tz) <= end:
-                set_status_indicator_to_on()
-        log_cron("Booting notifs scheduler")
-        sched.start()
-        log_cron("Done booting notifs scheduler")
         return sched
     except Exception as e:
         log_error("An error occurred in function schedule_jobs()")
@@ -133,16 +197,19 @@ def check_spreadsheet_maybe_schedule_new_notifs(scheds: list[BackgroundScheduler
             return
         log_cron("New datetimes detected - rescheduling jobs")
 
-        if AUTO_GENERATE_NOTIF_SCHEDULE:
-            notify_admins_of_schedule_change(times)
+        new_sched, active_notifs_window = _build_scheduler(times)
 
         log_cron("Shutting down current notifs scheduler")
-        scheds[-1].shutdown()  # stop and clear all current notifs jobs
-        update_notifs_schedule(times)  # update database
-        new_sched = schedule_jobs()  # schedule all new notifs jobs
+        old_sched = scheds[-1] if len(scheds) > 0 else None
+        if not _shutdown_scheduler(old_sched):
+            return
+
+        _sync_status_indicator(active_notifs_window)
+        _start_scheduler(new_sched)
+
         log_cron("Replacing notifs scheduler")
-        scheds.pop(0)
-        scheds.append(new_sched)
+        _replace_scheduler(scheds, new_sched)
+        _persist_notifs_schedule_if_changed(times)
         log_cron("Done updating notifs scheduler")
     except Exception as e:
         log_error(
@@ -167,6 +234,8 @@ if __name__ == "__main__":
 
     # perform one scheduling check initially
     new_sched = schedule_jobs(update_db=True)
+    if new_sched is None:
+        raise SystemExit(1)
     scheds = [new_sched]
 
     sched_spreadsheet_checker.add_job(

--- a/src/send_notifs.py
+++ b/src/send_notifs.py
@@ -294,6 +294,10 @@ def generate_time_intervals():
 
     # validate list of datetimes
     flat = [item for sublist in datetimes for item in sublist]
+    if len(flat) == 0:
+        log_warning("No future notification intervals found")
+        return []
+
     if not all(flat[i] < flat[i + 1] for i in range(len(flat) - 1)):
         log_error(
             "Datetime intervals either overlap or are not in ascending order - please update/fix the Schedule tab"

--- a/tests/test_notifs_schedule_regression.py
+++ b/tests/test_notifs_schedule_regression.py
@@ -1,0 +1,206 @@
+import importlib.util
+import sys
+import types
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytz
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ModulePatch:
+    def __init__(self, modules):
+        self.modules = modules
+        self.originals = {}
+
+    def __enter__(self):
+        for name, module in self.modules.items():
+            self.originals[name] = sys.modules.get(name)
+            sys.modules[name] = module
+
+    def __exit__(self, exc_type, exc, tb):
+        for name in self.modules:
+            original = self.originals[name]
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def make_module(name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    return module
+
+
+def load_module(name, path):
+    sys.modules.pop(name, None)
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeScheduler:
+    actions = []
+
+    def __init__(self):
+        self.jobs = []
+        self.running = False
+
+    def add_job(self, func, trigger, **kwargs):
+        self.jobs.append((func, trigger, kwargs))
+
+    def get_job(self, job_id):
+        return {"id": job_id}
+
+    def start(self):
+        self.running = True
+        self.actions.append("start")
+
+    def shutdown(self):
+        self.running = False
+        self.actions.append("shutdown")
+
+
+def noop(*args, **kwargs):
+    return None
+
+
+class NotifsCronRegressionTests(unittest.TestCase):
+    def load_cron(self):
+        FakeScheduler.actions = []
+        actions = []
+        tz = pytz.timezone("US/Eastern")
+        future_start = tz.localize(datetime.now() + timedelta(days=30))
+        future_end = future_start + timedelta(hours=2)
+        send_notifs = make_module(
+            "send_notifs",
+            AUTO_GENERATE_NOTIF_SCHEDULE=True,
+            cronjob=noop,
+            update_live_notifs_countdown=noop,
+            update_stats=noop,
+            set_status_indicator_to_on=lambda: actions.append("status_on"),
+            set_status_indicator_to_off=lambda log=True: actions.append("status_off"),
+            generate_time_intervals=lambda: [(future_start, future_end)],
+            did_notifs_spreadsheet_change=lambda times: True,
+            update_notifs_schedule=lambda times: actions.append("update"),
+        )
+        modules = {
+            "apscheduler": make_module("apscheduler"),
+            "apscheduler.schedulers": make_module("apscheduler.schedulers"),
+            "apscheduler.schedulers.background": make_module(
+                "apscheduler.schedulers.background",
+                BackgroundScheduler=FakeScheduler,
+            ),
+            "apscheduler.schedulers.blocking": make_module(
+                "apscheduler.schedulers.blocking",
+                BlockingScheduler=FakeScheduler,
+            ),
+            "_email_all_users": make_module(
+                "_email_all_users",
+                notify_admins_of_schedule_change=lambda times: actions.append("notify"),
+            ),
+            "_exec_update_all_courses": make_module(
+                "_exec_update_all_courses",
+                do_update_async_HARD=noop,
+                do_update_async_SOFT=noop,
+            ),
+            "config": make_module(
+                "config",
+                GLOBAL_COURSE_UPDATE_INTERVAL_MINS=10,
+                NOTIFS_INTERVAL_SECS=120,
+                NOTIFS_SHEET_POLL_MINS=1,
+                STATS_INTERVAL_MINS=10,
+            ),
+            "log_utils": make_module(
+                "log_utils",
+                log_cron=noop,
+                log_error=noop,
+                log_warning=noop,
+            ),
+            "send_notifs": send_notifs,
+        }
+        with ModulePatch(modules):
+            cron = load_module("send_notifs_cron", ROOT / "send_notifs_cron.py")
+        cron.actions = actions
+        return cron, actions
+
+    def test_reschedule_with_missing_current_scheduler_persists_before_email(self):
+        cron, actions = self.load_cron()
+
+        cron.check_spreadsheet_maybe_schedule_new_notifs([None])
+
+        self.assertIn("update", actions)
+        self.assertIn("notify", actions)
+        self.assertLess(actions.index("update"), actions.index("notify"))
+        self.assertNotIn("shutdown", FakeScheduler.actions)
+
+    def test_empty_schedule_still_starts_global_jobs_and_does_not_email(self):
+        cron, actions = self.load_cron()
+
+        sched = cron.schedule_jobs(update_db=True, times=[])
+
+        self.assertIsNotNone(sched)
+        self.assertTrue(sched.running)
+        self.assertEqual(len(sched.jobs), 4)
+        self.assertIn("update", actions)
+        self.assertNotIn("notify", actions)
+
+
+class SendNotifsRegressionTests(unittest.TestCase):
+    def test_generate_time_intervals_handles_no_future_calendar_events(self):
+        warnings = []
+
+        class FakeDatabase:
+            pass
+
+        class FakeCalendar:
+            @staticmethod
+            def from_ical(raw_cal_data):
+                return make_module("fake_calendar", walk=lambda: [])
+
+        class FakeResponse:
+            text = "BEGIN:VCALENDAR\nEND:VCALENDAR"
+
+            def raise_for_status(self):
+                return None
+
+        modules = {
+            "config": make_module(
+                "config",
+                AUTO_GENERATE_NOTIF_SCHEDULE=True,
+                NOTIFS_INTERVAL_SECS=120,
+                OIT_NOTIFS_OFFSET_MINS=5,
+            ),
+            "database": make_module("database", Database=FakeDatabase),
+            "icalendar": make_module("icalendar", Calendar=FakeCalendar),
+            "log_utils": make_module(
+                "log_utils",
+                log_error=noop,
+                log_warning=lambda message: warnings.append(message),
+                log_notifs=noop,
+            ),
+            "monitor": make_module("monitor", Monitor=object),
+            "multiprocess": make_module("multiprocess", Pool=object),
+            "notify": make_module(
+                "notify",
+                Notify=object,
+                send_email=noop,
+                send_text=noop,
+            ),
+            "requests": make_module("requests", get=lambda url: FakeResponse()),
+        }
+        with ModulePatch(modules):
+            send_notifs = load_module("send_notifs", ROOT / "src" / "send_notifs.py")
+
+        self.assertEqual(send_notifs.generate_time_intervals(), [])
+        self.assertIn("No future notification intervals found", warnings)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

- Handles empty auto-generated notification schedules without crashing schedule generation.
- Keeps the notifications scheduler bootable when there are no future notification windows, so stats and global course-update jobs still run.
- Persists schedule changes before emailing admins, preventing repeated `TigerSnatch Schedule Update` emails if the current scheduler is missing or already stopped.
- Adds regression coverage for missing scheduler recovery, empty schedule startup, and no future Registrar events.

## Why?

The May 6 notification incident exposed two compounding edge cases: `generate_time_intervals()` crashed when Registrar had no future notification windows available yet, and the one-minute schedule checker sent the admin email before saving the new schedule. If the current scheduler was `None`, the checker crashed before the DB update, so the same schedule-update email repeated every poll.

This keeps the notifier healthy during Registrar publication gaps and makes schedule-change emails idempotent against the persisted DB state.

## How to test

- [x] `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests`
- [x] `uvx black --check send_notifs_cron.py src/send_notifs.py tests/test_notifs_schedule_regression.py`
- [x] `python3 -m compileall send_notifs_cron.py src/send_notifs.py tests/test_notifs_schedule_regression.py`
- [x] `graphify update .`

## Checklist

- [x] Formatter check passes
- [x] Tested locally
- [x] Updated README or docs if needed
- [x] Added regression coverage for the May 6 schedule email storm edge case
- [x] Schedule update emails are sent only after the DB schedule is persisted
- [x] Empty future schedules do not prevent stats and course-update jobs from starting

_(PR Body Written by Codex)_
